### PR TITLE
RDKTV-36729 : btmgr take more time to shutdown.

### DIFF
--- a/include/btrCore_service.h
+++ b/include/btrCore_service.h
@@ -109,6 +109,11 @@ includes information for query of available services
 #define BTR_CORE_BATTERY_SERVICE_XBB_2 "0xe3bd"
 #define BTR_CORE_BATTERY_SERVICE_XBB_3 "0xd41d"
 
+#define BTR_CORE_REMOTE_SERVICE_TEXT "Remote Device"
+#define BTR_CORE_REMOTE_SERVICE_1 "0xf800"
+#define BTR_CORE_REMOTE_SERVICE_2 "0xf801"
+#define BTR_CORE_REMOTE_SERVICE_3 "0xf802"
+#define BTR_CORE_REMOTE_SERVICE_4 "0xf803"
 
 /* @} */ // End of group BLUETOOTH_TYPES
 

--- a/src/btrCore.c
+++ b/src/btrCore.c
@@ -1732,6 +1732,12 @@ btrCore_BTParseUUIDValue (
                  !strcasecmp(aUUID, BTR_CORE_BATTERY_SERVICE_XBB_3)) {
             STRCPY_S(pServiceNameOut, BTRCORE_STR_LEN, BTR_CORE_GATT_XBB_TEXT);
         }
+        else if (!strcasecmp(aUUID, BTR_CORE_REMOTE_SERVICE_1) ||
+                 !strcasecmp(aUUID, BTR_CORE_REMOTE_SERVICE_2) ||
+                 !strcasecmp(aUUID, BTR_CORE_REMOTE_SERVICE_3) ||
+                 !strcasecmp(aUUID, BTR_CORE_REMOTE_SERVICE_4)) {
+            STRCPY_S(pServiceNameOut, BTRCORE_STR_LEN, BTR_CORE_REMOTE_SERVICE_TEXT);
+        }
         else {
             STRCPY_S(pServiceNameOut, BTRCORE_STR_LEN, "Not Identified");
         }


### PR DESCRIPTION
Reason for change:
Avoided remote disconnections since it is handled by ctrl-mgr

Priority: P0
Test Procedure: Follow the steps provided in description.

Risks: High
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>