### PR TITLE
DELIA-68140: The controllers don't disconnect in standby

### DIFF
--- a/include/btrCore.h
+++ b/include/btrCore.h
@@ -1027,6 +1027,27 @@ enBTRCoreRet BTRCore_ReleaseDeviceDataPath(tBTRCoreHandle hBTRCore, tBTRCoreDevI
 enBTRCoreRet BTRCore_SetDeviceDataAckTimeout(tBTRCoreHandle hBTRCore, unsigned int aui32AckTOutms);
 
 /**
+ * @brief  This api adds all LE gamepads back to the action list in case they have been disconnected.
+ *
+ * @param[in]  hBTRCore           Bluetooth core handle.
+ *
+ * @return  Returns the status of the operation.
+ * @retval  Returns enBTRCoreSuccess on success, appropriate error code otherwise.
+ */
+
+enBTRCoreRet BTRCore_refreshLEActionListForGamepads(tBTRCoreHandle hBTRCore);
+
+/**
+ * @brief  This api removes all LE gamepads from the action list so they can not connect.
+ *
+ * @param[in]  hBTRCore           Bluetooth core handle.
+ *
+ * @return  Returns the status of the operation.
+ * @retval  Returns enBTRCoreSuccess on success, appropriate error code otherwise.
+ */
+enBTRCoreRet BTRCore_clearLEActionListForGamepads(tBTRCoreHandle hBTRCore);
+
+/**
  * @brief  This API starts the battery level thread to start querying battery levels for a newly connected device.
  *
  * @param[in]  hBTRCore           Bluetooth core handle.


### PR DESCRIPTION
Reason for change: as stable2 flex2 and legacy platforms don't shut down btmgr in deepsleep/standby, we need a different mechanism for disconnecting
Test Procedure: check that when you press the off button, all gamepads disconnect
Risks: Low
Priority: P1
Signed-off-by: Jack O'Gorman <jack.ogorman@sky.uk>

Change-Id: Ib1c5df4c7e38dc689e680c48067691600c405624 (cherry picked from commit 1bf289c5659321cf1c9ce5f44e32a1067ce36e50)