### PR TITLE
RDKTV-33661: bad use of sched_yield in RDK bluetooth code affecting performance

### DIFF
--- a/src/btrCore.c
+++ b/src/btrCore.c
@@ -2114,13 +2114,9 @@ btrCore_RunTask (
                 break;
             }
             case enBTRCoreTaskOpStop: {
-                g_thread_yield();
-
                 break;
             }
             case enBTRCoreTaskOpIdle: {
-                g_thread_yield();
-
                 break;
             }
             case enBTRCoreTaskOpProcess: {
@@ -2138,12 +2134,9 @@ btrCore_RunTask (
                 break;
             }
             case enBTRCoreTaskOpUnknown: {
-                g_thread_yield();
-
                 break;
             }
             default:
-                g_thread_yield();
                 break;
             }
             
@@ -2267,13 +2260,9 @@ btrCore_OutTask (
                 break;
             }
             case enBTRCoreTaskOpStop: {
-                g_thread_yield();
-
                 break;
             }
             case enBTRCoreTaskOpIdle: {
-                g_thread_yield();
-
                 break;
             }
             case enBTRCoreTaskOpProcess: {
@@ -3021,10 +3010,8 @@ btrCore_OutTask (
                     }
                 }
                 else if (lenOutTskPTCur == enBTRCoreTaskPTUnknown) {
-                    g_thread_yield();
                 }
                 else {
-                    g_thread_yield();
                 }
 
                 break;
@@ -3034,12 +3021,10 @@ btrCore_OutTask (
                 break;
             }
             case enBTRCoreTaskOpUnknown: {
-                g_thread_yield();
 
                 break;
             }
             default:
-                g_thread_yield();
                 break;
             }
 
@@ -3208,7 +3193,6 @@ BTRCore_Init (
 
     g_mutex_init(&pstlhBTRCore->batteryLevelMutex);
     g_cond_init(&pstlhBTRCore->batteryLevelCond);
-    sched_yield();
 
 
     pstlhBTRCore->curAdapterPath = BtrCore_BTGetAdapterPath(pstlhBTRCore->connHdl, NULL); //mikek hard code to default adapter for now

--- a/src/btrCore_avMedia.c
+++ b/src/btrCore_avMedia.c
@@ -1272,7 +1272,6 @@ BTRCore_AVMedia_GetCurMediaInfo (
         /* Max 4 sec timeout - Polled at 200ms second interval */
         unsigned int ui32sleepIdx = 20;
         do {
-            sched_yield();
             usleep(200000);
         } while ((!pstlhBTRCoreAVM->pcAVMediaTransportPathOut) && (--ui32sleepIdx));
 
@@ -1283,7 +1282,6 @@ BTRCore_AVMedia_GetCurMediaInfo (
         /* Max 4 sec timeout - Polled at 200ms second interval */
         unsigned int ui32sleepIdx = 20;
         do {
-            sched_yield();
             usleep(200000);
         } while ((!pstlhBTRCoreAVM->pcAVMediaTransportPathIn) && (--ui32sleepIdx));
 


### PR DESCRIPTION

Reason for change: To improve performance all calls to sched_yield and g_thread_yield should be removed, as they are not required.
Priority: P1
Test Procedure:
Risks: High


Signed-off-by: ddesal230 <Darshan_Desale@comcast.com>