### PR TITLE
DELIA-68456 : Crash on BtrCore_BTGetPairedDeviceInfo.

### DIFF
--- a/src/bt-ifce/btrCore_dbus_bluez5.c
+++ b/src/bt-ifce/btrCore_dbus_bluez5.c
@@ -4846,6 +4846,12 @@ BtrCore_BTGetPairedDeviceInfo (
 
         dbus_error_init(&lDBusErr);
 
+        // Check if message creation was successful and the connection is not closed yet.
+        if (lpDBusMsg == NULL || pstlhBtIfce->pDBusConn == NULL) {
+            BTRCORELOG_ERROR ("Failed to create message ...\n");
+            return -1;
+        }
+
         if (!dbus_connection_send_with_reply(pstlhBtIfce->pDBusConn, lpDBusMsg, &lpDBusPendC, -1)) {
             BTRCORELOG_ERROR ("failed to send message");
             return -1;


### PR DESCRIPTION
Reason for change:
Check whether the dbus connection exist before sending the dbus message to retrieve paired device info.

Priority: P1
Test Procedure: Follow the steps provided in description.

Risks: Low
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>