### PR TITLE
DELIA-68828 : Post connection failure

### DIFF
--- a/src/btrCore.c
+++ b/src/btrCore.c
@@ -4756,6 +4756,7 @@ BTRCore_ConnectDevice (
     /* Should think on moving a connected LE device from scanned list to paired list */
 
 
+	
     if ((lpstBTRCoreDevStateInfo->eDevicePrevState != enBTRCoreDevStConnected) &&
         (lpstBTRCoreDevStateInfo->eDeviceCurrState != enBTRCoreDevStPlaying)) {
         lpstBTRCoreDevStateInfo->eDevicePrevState  = lpstBTRCoreDevStateInfo->eDeviceCurrState;

--- a/src/btrCore.c
+++ b/src/btrCore.c
@@ -4756,7 +4756,6 @@ BTRCore_ConnectDevice (
     /* Should think on moving a connected LE device from scanned list to paired list */
 
 
-    lpstBTRCoreBTDevice->bDeviceConnected      = TRUE;
     if ((lpstBTRCoreDevStateInfo->eDevicePrevState != enBTRCoreDevStConnected) &&
         (lpstBTRCoreDevStateInfo->eDeviceCurrState != enBTRCoreDevStPlaying)) {
         lpstBTRCoreDevStateInfo->eDevicePrevState  = lpstBTRCoreDevStateInfo->eDeviceCurrState;


### PR DESCRIPTION
Reason for change: skipped marking the device as connected after invoking the connect method for bluez.
Test Procedure: Perform the steps metioned in description.
Risks: Medium
Priority: P1