### PR TITLE
RDKEMW-12176: DonotMerge

### DIFF
--- a/src/btrCore.c
+++ b/src/btrCore.c
@@ -1505,6 +1505,7 @@ btrCore_PopulateListOfPairedDevices (
     }
 
     /* Initially stBTRCoreKnownDevice List is populated from pstBTPairedDeviceInfo(bluez i/f) directly *********/  
+    /* Dummy change */
     if (!apsthBTRCore->numOfPairedDevices) { 
         apsthBTRCore->numOfPairedDevices = pstBTPairedDeviceInfo->numberOfDevices;
         btrCore_MapKnownDeviceListFromPairedDeviceInfo (knownDevicesArr, pstBTPairedDeviceInfo); 


### PR DESCRIPTION
Reason for change: Unit tests failure check
Test Procedure: Device deepsleep causing the crash
Risks: Low
Priority: P2