### PR TITLE
RDKEMW-12176: UT Fail test - donot merge

### DIFF
--- a/src/btrCore.c
+++ b/src/btrCore.c
@@ -1192,6 +1192,7 @@ btrCore_AddDeviceToScannedDevicesArr (
             lstFoundDevice.stAdServiceData[count].len = apstBTDeviceInfo->saServices[count].len;
             MEMCPY_S(lstFoundDevice.stAdServiceData[count].pcData,lstFoundDevice.stAdServiceData[count].len, apstBTDeviceInfo->saServices[count].pcData, BTRCORE_MAX_SERVICE_DATA_LEN);
 
+
             BTRCORELOG_TRACE ("ServiceData from %s\n", __FUNCTION__);
             for (int i =0; i < apstBTDeviceInfo->saServices[count].len; i++){
                 BTRCORELOG_TRACE ("ServiceData[%d] = [%x]\n ", i, lstFoundDevice.stAdServiceData[count].pcData[i]);


### PR DESCRIPTION
Reason for change: Crash fix
Test Procedure: Device deepsleep causing the crash
Risks: Low
Priority: P2